### PR TITLE
Changed GlobalEventFit DiTauConstrainedFitter & LagrangeMultipliersFitter

### DIFF
--- a/FitSoftware/interface/DiTauConstrainedFitter.h
+++ b/FitSoftware/interface/DiTauConstrainedFitter.h
@@ -25,9 +25,7 @@ class DiTauConstrainedFitter : public LagrangeMultipliersFitter{
 
   enum ParsTrunc{tau_px=0,tau_py,tau_pz,npartr};
 
-
-  virtual bool Fit();
-  virtual double NConstraints(){if(!useFullRecoil_) return 2; return 2;}
+  virtual double NConstraints(){ return 2;}
   virtual double NSoftConstraints(){if(!useFullRecoil_) return 3; return 2;}
   virtual double NDF(){return 1;}
   virtual int    NDaughters(){return 2;}
@@ -47,11 +45,8 @@ class DiTauConstrainedFitter : public LagrangeMultipliersFitter{
  protected:
   virtual TVectorD HardValue(TVectorD &va,TVectorD &vb);
   virtual TVectorD SoftValue(TVectorD &va,TVectorD &vb);
-    
+
  private:
-
-    LorentzVectorParticle EstimateTauMu(TVector3 PV,  TMatrixTSym<double>  PVCov, TVector3 SV, TMatrixTSym<double>  SVCov, TrackParticle MuTrack,LorentzVectorParticle TauA1, double ZMassR);
-
 
   static TMatrixT<double> ComputeInitalExpPar(TMatrixT<double> &inpar);
   static TMatrixT<double> ComputeExpParToPar(TMatrixT<double> &inpar);
@@ -61,16 +56,8 @@ class DiTauConstrainedFitter : public LagrangeMultipliersFitter{
   static TMatrixT<double> ComputeTauA1LorentzVectorPar(TMatrixT<double> &inpar);
   static TMatrixT<double> ComputeMotherLorentzVectorPar(TMatrixT<double> &inpar);
 
-  std::vector<double>  ReturnDecayPoint(TrackParticle MuTrack, TLorentzVector MuonLV, TVector3 PV,TVector3 SV,TVector3 TauDir,TVector3 TauDirError);
-  TVector3 IntersectionPoint(TVector3 PV,TVector3 SV,double xc, double yc, double r);
-  LorentzVectorParticle IntersectionPointLinearApproximation(TVector3 PV,TVector3 SV, TVector3 MuonPoca, TLorentzVector MuonLV,TrackParticle MuTrack,TVector3 TauDirError,LorentzVectorParticle TauA1);
-
-  LorentzVectorParticle ConvertTrackParticleToLorentzVectorParticle(TrackParticle MuTrack);
-
   void UpdateExpandedPar();
   void CovertParToObjects(TVectorD &va,TVectorD &vb,TLorentzVector &Taua1,TLorentzVector &Taumu, double &Zmass);
- 
- 
 
   LorentzVectorParticle  TauMuStartingPoint(TrackParticle MuTrack,LorentzVectorParticle TauA1, TVector3 PV,TMatrixTSym<double>  PVCov, TVector3 SV, TMatrixTSym<double>  SVCov);
   static TMatrixT<double> EstimateTauDirectionAdvanced(TMatrixT<double> &inpar);
@@ -84,18 +71,13 @@ class DiTauConstrainedFitter : public LagrangeMultipliersFitter{
   TMatrixT<double> ComputeAngleCovarianceAnalytically(TrackParticle MuTrack, std::pair<double, double> phiAngle,  TVector3 PV, TVector3 SV, LorentzVectorParticle  TauA1);
   std::pair<double, double> EstimatePhiAngle( TVector3 dir, TVector3 dirE);
 
-  TMatrixT<double> ConfigureMuTrackTauA1Parameters(TrackParticle Muon, LorentzVectorParticle TauA1);
-  TMatrixTSym<double> ConfigureMuTrackTauA1Errors(TrackParticle Muon, LorentzVectorParticle TauA1);
-
   LorentzVectorParticle TauMuStartingPointwithFullRecoil(TrackParticle MuTrack,LorentzVectorParticle TauA1, PTObject METminusNeutrino, TVector3 PV, TMatrixTSym<double>  PVCov, TVector3 SV, TMatrixTSym<double>  SVCov);
-  TMatrixT<double> ConfigureTauMuPtParameters(TrackParticle Muon, PTObject METminusNeutrino);
-  TMatrixTSym<double> ConfigureTauMuPtParameterErrors(TrackParticle Muon, PTObject METminusNeutrino);
-  static TMatrixT<double> EstimateTauPt(TMatrixT<double> &inpar);
-  TMatrixT<double> ConfigureKinematicParametersFullRecoil(TrackParticle MuTrack, TVector3 PV, LorentzVectorParticle TauA1, TMatrixT<double> TauMuPt);
-  TMatrixTSym<double> ConfigureKinematicParameterErrorsFullRecoil(TrackParticle MuTrack, TMatrixTSym<double> PVCov, LorentzVectorParticle TauA1, TMatrixTSym<double> TauMuPtCov);
+  TMatrixT<double> ConfigureKinematicParametersFullRecoil(TrackParticle MuTrack, TVector3 PV, LorentzVectorParticle TauA1, PTObject METminusNeutrino);
+  TMatrixTSym<double> ConfigureKinematicParameterErrorsFullRecoil(TrackParticle MuTrack, TMatrixTSym<double> PVCov, LorentzVectorParticle TauA1, PTObject METminusNeutrino);
   static TMatrixT<double> EstimateTauKinematicFullRecoil(TMatrixT<double> &inpar);
+  TMatrixDSym EstimateTauKinematicErrorFullRecoil(LorentzVectorParticle TauA1, TLorentzVector TauMu, PTObject ResPtEstimate);
 
-  void SetRecoil(TMatrixD &inpar);
+  double CosThetaTauMu(TLorentzVector TauMu);
 
   TMatrixT<double> exppar;
   TMatrixTSym<double> expcov;
@@ -104,15 +86,15 @@ class DiTauConstrainedFitter : public LagrangeMultipliersFitter{
   TMatrixT<double> expparb;
   TMatrixTSym<double> expcovb;
 
-
-
   std::vector<LorentzVectorParticle> particles_, particles0_;
 
   LorentzVectorParticle Init_Resonance_;
-  double ThetaForConstrTemporaryIMplementation_;
-  double phiz_, ptz_;
+  TrackParticle MuTrack_;
+  TVector3 PV_;
+  double ThetaForConstrTemporaryImplementation_;
+  double phiz_;
   double RecoilX_, RecoilY_;
-  PTObject METminusNeutrino_;
+  PTObject ResPtEstimate_;
   bool debug;
   bool AnalyticalCovariance;
   int ConstraintMode;

--- a/FitSoftware/interface/GlobalEventFit.h
+++ b/FitSoftware/interface/GlobalEventFit.h
@@ -50,6 +50,8 @@ class GlobalEventFit{
 	TPTRObject ThreeProngTauReconstruction();
 	bool IsAmbiguous(std::vector<bool> recostatus);
 	PTObject SubtractNeutrinoFromMET(unsigned Ambiguity);
+	PTObject AddA1(PTObject MET);
+	PTObject AddMuon(PTObject MET);
 
   private:
 	bool isConfigured_;

--- a/FitSoftware/interface/LagrangeMultipliersFitter.h
+++ b/FitSoftware/interface/LagrangeMultipliersFitter.h
@@ -2,6 +2,7 @@
 #define LagrangeMultipliersFitter_H
 
 #include "SimpleFits/FitSoftware/interface/LorentzVectorParticle.h"
+#include "SimpleFits/FitSoftware/interface/PDGInfo.h"
 #include "TMatrixT.h"
 #include "TVectorT.h"
 #include "TMatrixTSym.h"
@@ -54,7 +55,6 @@ class LagrangeMultipliersFitter{
   virtual TVectorD SoftValue(TVectorD &va,TVectorD &vb)=0;
 
 
-
   TVectorD par_0; // parameter values for linearization point
   TVectorD par; // current parameter values
   TMatrixTSym<double> cov_0; //covariance matrix for linearization point (corresponding to par_0) 
@@ -63,12 +63,12 @@ class LagrangeMultipliersFitter{
 
   //  a and b denotes taua1 and taumu parameters correspondingly
   TVectorD para_0; // parameter values for linearization point
-  TVectorD para; // current parameter values
+  TVectorD para, paraprev; // current parameter values
   TMatrixTSym<double> cova_0; //covariance matrix for linearization point (corresponding to par_0) 
   TMatrixTSym<double> cova; // current covariance matrix (corresponding to par) 
 
   TVectorD parb_0; // parameter values for linearization point
-  TVectorD parb; // current parameter values
+  TVectorD parb, parbprev; // current parameter values
   TMatrixTSym<double> covb_0; //covariance matrix for linearization point (corresponding to par_0) 
   TMatrixTSym<double> covb; // current covariance matrix (corresponding to par) 
 
@@ -96,11 +96,11 @@ class LagrangeMultipliersFitter{
   TMatrixT<double> ComputeVarianceb();
 
   // Configuration parameters
-  double epsilon_,weight_,MaxDelta_,nitermax_,MaxParDelta_;
+  double epsilon_,weight_,MaxDelta_,nitermax_,MaxParDelta_, MaxHCDelta_, MaxSCDelta_, MaxChi2Delta_, nCutStepmax_;
 
   // Fit variables
   double chi2,chi2prev,delta,niter,pardelta, pardeltaprev;
-  TVectorD harddelta_vec, softdelta_vec, chi2_vec;
+  TVectorD harddelta_vec, harddelta_vecprev, softdelta_vec, softdelta_vecprev, chi2_vec;
 
   // covariances and derivatives info
 


### PR DESCRIPTION
Changes to GlobalEventFit interface:
- Resonance pt estimate with MET is now estimated without the
  reconstructed neutrino from the threeprong reconstruction, but with
the a1 and muon (added two functions to do this)
- solution for ambiguous events is now picked by the part of the hard
  constraints in the "chi2" function (yields best results)

Changes to DiTauConstrainedFitter:

- cleanup of the header file (removed a lot of function that were not
  even implemented anymore)
- removed more unused functions in the source file
- changed the theta hard constraint from "pz/p - cos(theta)" to "pz -
  p*cos(theta)". Seems to give more reasonable derivatives and therefore
error calculations

Changes to LagrangeMultipliersFitter:

- changed number of maximum iterations to 1000. Is not necessary for
  most events but helps in some cases
- implemented some kind of CutStep method. If the deviations from the
  hardconstraints raise from one to another iteration of the fit, the
changes of the fit parameter are reduced iteratively until the
deviations are smaller again (this prevents overshooting during chi2
minimization in a few cases, still most fit failures are due to an
overshoot)
- convergence for both methods is now defined as following: chi2 of the
  measured particles (original/real chi2 term) must not differ from last
iteration by over 0.01 and deviations from hardconstraints must be
smaller than 0.001